### PR TITLE
Update Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://www.iterm2.com/downloads.html
 
 ### HomeBrew
 ```sh
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 ### Dropbox


### PR DESCRIPTION
> The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash.